### PR TITLE
Dash_30 管理者トップ画面のリプレイス

### DIFF
--- a/components/NavigationDrawer.vue
+++ b/components/NavigationDrawer.vue
@@ -1,0 +1,106 @@
+<template>
+  <div>
+   <v-app-bar clipped-left fixed app>
+      <v-app-bar-nav-icon @click.stop="drawer = !drawer" />
+      <v-btn icon>
+        <v-icon>mdi-application</v-icon>
+      </v-btn>
+      <v-toolbar-title class="ml-2"><v-btn>{{ title }}</v-btn></v-toolbar-title>
+      <v-spacer />
+    </v-app-bar>
+    <v-navigation-drawer
+        v-model="drawer"
+        clipped
+        fixed
+        app
+    >
+      <v-list>
+        <v-list-item
+          v-for="(item, i) in items"
+          :key="i"
+          :to="item.to"
+          router
+          exact
+        >
+          <v-list-item-action>
+            <v-icon>{{ item.icon }}</v-icon>
+          </v-list-item-action>
+          <v-list-item-content>
+            <v-list-item-title>{{ item.title }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+      <!-- ログアウト -->
+      <v-list v-if="this.$auth.loggedIn">
+        <v-list-item>
+          <v-list-item-action>
+            <v-icon icon="mdi-close"></v-icon>
+          </v-list-item-action>
+          <v-list-item-content>
+            <v-list-item-title><v-btn @click="logout()" role="button">Logout</v-btn></v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-navigation-drawer>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      drawer: false,
+      fixed: false,
+      items: [
+        {
+          icon: 'mdi-apps',
+          title: 'Welcome',
+          to: '/',
+        },
+        {
+          icon: 'mdi-chart-bubble',
+          title: 'Inspire',
+          to: '/inspire',
+        },
+        {
+          icon: 'mdi-chart-bubble',
+          title: 'Inspire',
+          to: '/inspire',
+        },
+        {
+          icon: 'mdi-chart-bubble',
+          title: 'Inspire',
+          to: '/inspire',
+        },
+      ],
+      title: 'B-Dash',
+    }
+  },
+  // methods: {
+  //     async login() {
+  //       try {
+  //         const response = await this.$auth.loginWith('laravelSanctum', { data: this.form });
+  //         this.$auth.setUser(response.data[0]);
+  //         await this.$auth.fetchUser();
+  //         console.log(response);
+  //       } catch(error) {
+  //         console.log(error);
+  //       }
+  //     },
+  //   },
+  methods: {
+    async logout() {
+      try{
+        const response = await this.$auth.logout();
+        console.log(response);
+      }catch(error){
+        console.log(error);
+      }
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/components/NavigationDrawer.vue
+++ b/components/NavigationDrawer.vue
@@ -34,7 +34,7 @@
       <v-list v-if="this.$auth.loggedIn">
         <v-list-item>
           <v-list-item-action>
-            <v-icon icon="mdi-close"></v-icon>
+            <v-icon>mdi-logout</v-icon>
           </v-list-item-action>
           <v-list-item-content>
             <v-list-item-title><v-btn @click="logout()" role="button">Logout</v-btn></v-list-item-title>
@@ -54,40 +54,83 @@ export default {
       items: [
         {
           icon: 'mdi-apps',
-          title: 'Welcome',
+          title: 'Top',
           to: '/',
         },
         {
           icon: 'mdi-chart-bubble',
-          title: 'Inspire',
-          to: '/inspire',
+          title: '月報トップ',
+          to: '/',
+        },
+        {
+          icon: 'mdi-pencil',
+          title: '月報編集',
+          to: '/',
         },
         {
           icon: 'mdi-chart-bubble',
-          title: 'Inspire',
-          to: '/inspire',
+          title: 'マイ月報',
+          to: '/',
         },
         {
           icon: 'mdi-chart-bubble',
-          title: 'Inspire',
+          title: 'ブログトップ',
+          to: '/',
+        },
+        {
+          icon: 'mdi-chart-bubble',
+          title: 'ブログ新規投稿',
+          to: '/',
+        },
+        {
+          icon: 'mdi-chart-bubble',
+          title: 'マイブログ',
+          to: '/',
+        },
+        {
+          icon: 'mdi-chart-bubble',
+          title: 'お気に入りブログ',
+          to: '/',
+        },
+        {
+          icon: 'mdi-chart-bubble',
+          title: 'QAトップ',
+          to: '/',
+        },
+        {
+          icon: 'mdi-chart-bubble',
+          title: '質問投稿',
+          to: '/',
+        },
+        {
+          icon: 'mdi-chart-bubble',
+          title: 'マイ質問',
+          to: '/',
+        },
+        {
+          icon: 'mdi-magnify',
+          title: 'ユーザー検索',
+          to: '/',
+        },
+        {
+          icon: 'mdi-chart-bubble',
+          title: 'プロフィール',
+          to: '/inspire',
+        },
+        {
+          icon: 'mdi-lock',
+          title: 'パスワード変更',
+          to: '/inspire',
+        },
+        {
+          icon: 'mdi-chat-question',
+          title: 'お問い合わせ',
           to: '/inspire',
         },
       ],
       title: 'B-Dash',
     }
   },
-  // methods: {
-  //     async login() {
-  //       try {
-  //         const response = await this.$auth.loginWith('laravelSanctum', { data: this.form });
-  //         this.$auth.setUser(response.data[0]);
-  //         await this.$auth.fetchUser();
-  //         console.log(response);
-  //       } catch(error) {
-  //         console.log(error);
-  //       }
-  //     },
-  //   },
   methods: {
     async logout() {
       try{

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,67 +1,24 @@
 <template>
   <v-app dark>
-    <v-navigation-drawer
-      v-model="drawer"
-      clipped
-      fixed
-      app
-    >
-      <v-list>
-        <v-list-item
-          v-for="(item, i) in items"
-          :key="i"
-          :to="item.to"
-          router
-          exact
-        >
-          <v-list-item-action>
-            <v-icon>{{ item.icon }}</v-icon>
-          </v-list-item-action>
-          <v-list-item-content>
-            <v-list-item-title>{{ item.title }}</v-list-item-title>
-          </v-list-item-content>
-        </v-list-item>
-      </v-list>
-    </v-navigation-drawer>
-    <v-app-bar clipped-left fixed app>
-      <v-app-bar-nav-icon @click.stop="drawer = !drawer" />
-      <v-btn icon>
-        <v-icon>mdi-application</v-icon>
-      </v-btn>
-      <v-toolbar-title class="ml-2">{{ title }}</v-toolbar-title>
-      <v-spacer />
-    </v-app-bar>
+    <NavigationDrawer />
     <v-main>
       <v-container>
         <Nuxt />
       </v-container>
     </v-main>
-    <v-footer :absolute="!fixed" app>
+    <v-footer absolute app>
       <span class="mx-auto">&copy; {{ new Date().getFullYear() }}</span>
     </v-footer>
   </v-app>
 </template>
 
 <script>
+import NavigationDrawer from '../components/NavigationDrawer.vue'
 export default {
+  components: { NavigationDrawer },
   name: 'DefaultLayout',
   data() {
     return {
-      drawer: false,
-      fixed: false,
-      items: [
-        {
-          icon: 'mdi-apps',
-          title: 'Welcome',
-          to: '/',
-        },
-        {
-          icon: 'mdi-chart-bubble',
-          title: 'Inspire',
-          to: '/inspire',
-        },
-      ],
-      title: 'B-Dash',
     }
   },
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,64 +1,62 @@
 <template>
-    <v-main>
-      <v-container
-        class="py-8 px-6"
-        fluid
-      >
-        <v-row>
-          <v-col
-            v-for="card in cards"
-            :key="card"
-            cols="12"
-          >
-            <v-card>
-              <v-subheader>{{ card }}</v-subheader>
-              <v-list two-line>
-                <template v-for="n in 6">
-                  <v-list-item
-                    :key="n"
-                  >
-                    <v-list-item-avatar color="grey darken-1">
-                    </v-list-item-avatar>
+    <v-container
+      class="py-8 px-6"
+      fluid
+    >
+      <v-row>
+        <v-col
+          v-for="card in cards"
+          :key="card"
+          cols="12"
+        >
+          <v-card>
+            <v-subheader>{{ card }}</v-subheader>
+            <v-list two-line>
+              <template v-for="n in 6">
+                <v-list-item
+                  :key="n"
+                >
+                  <v-list-item-avatar color="grey darken-1">
+                  </v-list-item-avatar>
 
-                    <v-list-item-content>
-                      <v-list-item-title>Message {{ n }}</v-list-item-title>
+                  <v-list-item-content>
+                    <v-list-item-title>Message {{ n }}</v-list-item-title>
 
-                      <v-list-item-subtitle>
-                        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nihil repellendus distinctio similique
-                      </v-list-item-subtitle>
-                      <div class="d-flex flex-row justify-end">
-                        <template v-for="m in 3">
-                          <v-chip
-                            x-small
-                            class="ma-2"
-                            color="green"
-                            text-color="white"
-                            :key="m"
-                            >
-                            タグ
-                          </v-chip>
-                        </template>
-                        <v-icon x-small>mdi-message</v-icon><span class="ma-2" style="font-size : x-small">コメント数</span>
-                        <v-icon x-small>mdi-thumb-up-outline</v-icon><span class="ma-2" style="font-size : x-small">いいね数</span>
-                      </div>
-                    </v-list-item-content>
-                  </v-list-item>
+                    <v-list-item-subtitle>
+                      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nihil repellendus distinctio similique
+                    </v-list-item-subtitle>
+                    <div class="d-flex flex-row justify-end">
+                      <template v-for="m in 3">
+                        <v-chip
+                          x-small
+                          class="ma-2"
+                          color="green"
+                          text-color="white"
+                          :key="m"
+                          >
+                          タグ
+                        </v-chip>
+                      </template>
+                      <v-icon x-small>mdi-message</v-icon><span class="ma-2" style="font-size : x-small">コメント数</span>
+                      <v-icon x-small>mdi-thumb-up-outline</v-icon><span class="ma-2" style="font-size : x-small">いいね数</span>
+                    </div>
+                  </v-list-item-content>
+                </v-list-item>
 
-                  <v-divider
-                    v-if="n !== 6"
-                    :key="`divider-${n}`"
-                    inset
-                  ></v-divider>
-                </template>
-              </v-list>
-            </v-card>
-            <div class="d-flex flex-row justify-end mt-2">
-              <v-btn to="/">こちら</v-btn>
-            </div>
-          </v-col>
-        </v-row>
-      </v-container>
-    </v-main>
+                <v-divider
+                  v-if="n !== 6"
+                  :key="`divider-${n}`"
+                  inset
+                ></v-divider>
+              </template>
+            </v-list>
+          </v-card>
+          <div class="d-flex flex-row justify-end mt-2">
+            <v-btn to="/">こちら</v-btn>
+          </div>
+        </v-col>
+      </v-row>
+    </v-container>
 </template>
 
 <script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,87 +1,72 @@
 <template>
-  <v-row justify="center" align="center">
-    <v-col cols="12" sm="8" md="6">
-      <v-card class="logo py-4 d-flex justify-center">
-        <NuxtLogo />
-        <VuetifyLogo />
-      </v-card>
-      <v-card>
-        <v-card-title class="headline">
-          Welcome to the Vuetify + Nuxt.js template
-        </v-card-title>
-        <v-card-text>
-          <p>
-            Vuetify is a progressive Material Design component framework for
-            Vue.js. It was designed to empower developers to create amazing
-            applications.
-          </p>
-          <p>
-            For more information on Vuetify, check out the
-            <a
-              href="https://vuetifyjs.com"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              documentation </a
-            >.
-          </p>
-          <p>
-            If you have questions, please join the official
-            <a
-              href="https://chat.vuetifyjs.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-              title="chat"
-            >
-              discord </a
-            >.
-          </p>
-          <p>
-            Find a bug? Report it on the github
-            <a
-              href="https://github.com/vuetifyjs/vuetify/issues"
-              target="_blank"
-              rel="noopener noreferrer"
-              title="contribute"
-            >
-              issue board </a
-            >.
-          </p>
-          <p>
-            Thank you for developing with Vuetify and I look forward to bringing
-            more exciting features in the future.
-          </p>
-          <div class="text-xs-right">
-            <em><small>&mdash; John Leider</small></em>
-          </div>
-          <hr class="my-3" />
-          <a
-            href="https://nuxtjs.org/"
-            target="_blank"
-            rel="noopener noreferrer"
+    <v-main>
+      <v-container
+        class="py-8 px-6"
+        fluid
+      >
+        <v-row>
+          <v-col
+            v-for="card in cards"
+            :key="card"
+            cols="12"
           >
-            Nuxt Documentation
-          </a>
-          <br />
-          <a
-            href="https://github.com/nuxt/nuxt.js"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Nuxt GitHub
-          </a>
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn color="primary" nuxt to="/inspire"> Continue </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-col>
-  </v-row>
+            <v-card>
+              <v-subheader>{{ card }}</v-subheader>
+              <v-list two-line>
+                <template v-for="n in 6">
+                  <v-list-item
+                    :key="n"
+                  >
+                    <v-list-item-avatar color="grey darken-1">
+                    </v-list-item-avatar>
+
+                    <v-list-item-content>
+                      <v-list-item-title>Message {{ n }}</v-list-item-title>
+
+                      <v-list-item-subtitle>
+                        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nihil repellendus distinctio similique
+                      </v-list-item-subtitle>
+                      <div class="d-flex flex-row justify-end">
+                        <template v-for="m in 3">
+                          <v-chip
+                            x-small
+                            class="ma-2"
+                            color="green"
+                            text-color="white"
+                            :key="m"
+                            >
+                            タグ
+                          </v-chip>
+                        </template>
+                        <v-icon x-small>mdi-message</v-icon><span class="ma-2" style="font-size : x-small">コメント数</span>
+                        <v-icon x-small>mdi-thumb-up-outline</v-icon><span class="ma-2" style="font-size : x-small">いいね数</span>
+                      </div>
+                    </v-list-item-content>
+                  </v-list-item>
+
+                  <v-divider
+                    v-if="n !== 6"
+                    :key="`divider-${n}`"
+                    inset
+                  ></v-divider>
+                </template>
+              </v-list>
+            </v-card>
+            <div class="d-flex flex-row justify-end mt-2">
+              <v-btn to="/">こちら</v-btn>
+            </div>
+          </v-col>
+        </v-row>
+      </v-container>
+    </v-main>
 </template>
 
 <script>
-export default {
-  name: 'IndexPage',
-}
+  export default {
+    data: () => ({
+      // 将来的に、cardの中身はオブジェクト化し、3コンテンツそれぞれでtitle, 取得データ, リンクなどを設定する
+      cards: ['お知らせ一覧', '最近投稿された月報','フォローしているユーザーの月報'],
+    }),
+    name: 'indexページ',
+  }
 </script>


### PR DESCRIPTION
## 対応チケット
[Dash_30 管理者トップ画面のリプレイス](https://gonzuiswimmer.atlassian.net/browse/DASH-30)

## やったこと
- トップ画面を実装


## 動作確認
- 画面キャプチャ
<img width="767" alt="image" src="https://github.com/gonzuiswimmer/dash_replace2_front/assets/115978255/a97ff62b-824a-4a20-943c-202ec8d4c483">


## その他
- データの受け渡しについては未実装のため、別チケットにて対応予定
- 一般ユーザーのトップ画面とルーティングは同じ。表示内容が変わる予定だが、認証機能が不十分なため、別途対応予定
