### PR TITLE
DASH_31 管理者トップ画面にバックエンドから情報を受け渡す

### DIFF
--- a/components/announcementsCard.vue
+++ b/components/announcementsCard.vue
@@ -1,0 +1,64 @@
+<template>
+  <v-col cols="12">
+    <v-card>
+      <v-subheader>{{ announcements.contentTitle }}</v-subheader>
+      <v-list two-line>
+        <template v-for="(content, index) in announcements.data">
+          <v-list-item
+            :key="index"
+          >
+            <v-list-item-avatar color="grey darken-1">
+            </v-list-item-avatar>
+
+            <v-list-item-content>
+              <v-list-item-title>名前 <span>【所属:yyy年mm月入社】</span> </v-list-item-title>
+
+              <v-list-item-subtitle>
+                {{ content.title }}
+              </v-list-item-subtitle>
+              <div class="d-flex flex-row justify-end">
+                <template v-for="m in 3">
+                  <v-chip
+                    x-small
+                    class="ma-2"
+                    color="green"
+                    text-color="white"
+                    :key="m"
+                    >
+                    タグ
+                  </v-chip>
+                </template>
+                <v-icon x-small>mdi-message</v-icon><span class="ma-2" style="font-size : x-small">コメント数</span>
+                <v-icon x-small>mdi-thumb-up-outline</v-icon><span class="ma-2" style="font-size : x-small">いいね数</span>
+              </div>
+            </v-list-item-content>
+          </v-list-item>
+
+          <v-divider
+            v-if="index !== 3"
+            :key="`divider-${index}`"
+            inset
+          ></v-divider>
+        </template>
+      </v-list>
+    </v-card>
+    <div class="d-flex flex-row justify-end mt-2">
+      <v-btn to="/">{{ announcements.contentTitle }}一覧はこちら</v-btn>
+    </div>
+  </v-col>
+</template>
+
+<script>
+export default {
+  props: {
+    announcements: {
+      type: Object,
+      default: {},
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/components/recentReportsCard.vue
+++ b/components/recentReportsCard.vue
@@ -1,0 +1,64 @@
+<template>
+  <v-col cols="12">
+    <v-card>
+      <v-subheader>{{ recentReports.contentTitle }}</v-subheader>
+      <v-list two-line>
+        <template v-for="(content, index) in recentReports.data">
+          <v-list-item
+            :key="index"
+          >
+            <v-list-item-avatar color="grey darken-1">
+            </v-list-item-avatar>
+
+            <v-list-item-content>
+              <v-list-item-title>{{ content.user.name }}<span>【所属:{{content.user.department_id}}/{{content.user.entry_date}}入社】</span> </v-list-item-title>
+
+              <v-list-item-subtitle>
+                {{ content.business_content }}
+              </v-list-item-subtitle>
+              <div class="d-flex flex-row justify-end">
+                <template v-for="(tag, index) in content.tags">
+                  <v-chip
+                    x-small
+                    class="ma-2"
+                    color="green"
+                    text-color="white"
+                    :key="index"
+                    >
+                    {{ tag.name }}
+                  </v-chip>
+                </template>
+                <v-icon x-small>mdi-message</v-icon><span class="ma-2" style="font-size : x-small">{{content.comments_count}}</span>
+                <v-icon x-small>mdi-thumb-up-outline</v-icon><span class="ma-2" style="font-size : x-small">{{content.comments_count}}</span>
+              </div>
+            </v-list-item-content>
+          </v-list-item>
+
+          <v-divider
+            v-if="index !== 3"
+            :key="`divider-${index}`"
+            inset
+          ></v-divider>
+        </template>
+      </v-list>
+    </v-card>
+    <div class="d-flex flex-row justify-end mt-2">
+      <v-btn to="/">{{ recentReports.contentTitle }}一覧はこちら</v-btn>
+    </div>
+  </v-col>
+</template>
+
+<script>
+export default {
+  props: {
+    recentReports: {
+      type: Object,
+      default: {},
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/components/reportsOfFollowingUserCard.vue
+++ b/components/reportsOfFollowingUserCard.vue
@@ -1,0 +1,64 @@
+<template>
+  <v-col cols="12">
+    <v-card>
+      <v-subheader>{{ reportsOfFollowingUser.contentTitle }}</v-subheader>
+      <v-list two-line>
+        <template v-for="(content, index) in reportsOfFollowingUser.data">
+          <v-list-item
+            :key="index"
+          >
+            <v-list-item-avatar color="grey darken-1">
+            </v-list-item-avatar>
+
+            <v-list-item-content>
+              <v-list-item-title>{{ content.user.name }}<span>【所属:{{content.user.department_id}}/{{content.user.entry_date}}入社】</span> </v-list-item-title>
+
+              <v-list-item-subtitle>
+                {{ content.business_content }}
+              </v-list-item-subtitle>
+              <div class="d-flex flex-row justify-end">
+                <template v-for="(tag, index) in content.tags">
+                  <v-chip
+                    x-small
+                    class="ma-2"
+                    color="green"
+                    text-color="white"
+                    :key="index"
+                    >
+                    {{ tag.name }}
+                  </v-chip>
+                </template>
+                <v-icon x-small>mdi-message</v-icon><span class="ma-2" style="font-size : x-small">{{content.comments_count}}</span>
+                <v-icon x-small>mdi-thumb-up-outline</v-icon><span class="ma-2" style="font-size : x-small">{{content.likes_count}}</span>
+              </div>
+            </v-list-item-content>
+          </v-list-item>
+
+          <v-divider
+            v-if="index !== 3"
+            :key="`divider-${index}`"
+            inset
+          ></v-divider>
+        </template>
+      </v-list>
+    </v-card>
+    <div class="d-flex flex-row justify-end mt-2">
+      <v-btn to="/">{{ reportsOfFollowingUser.contentTitle }}一覧はこちら</v-btn>
+    </div>
+  </v-col>
+</template>
+
+<script>
+export default {
+  props: {
+    reportsOfFollowingUser: {
+      type: Object,
+      default: {},
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,70 +1,45 @@
 <template>
-    <v-container
-      class="py-8 px-6"
-      fluid
-    >
+    <v-container class="py-8 px-6" fluid>
       <v-row>
-        <v-col
-          v-for="card in cards"
-          :key="card"
-          cols="12"
-        >
-          <v-card>
-            <v-subheader>{{ card }}</v-subheader>
-            <v-list two-line>
-              <template v-for="n in 6">
-                <v-list-item
-                  :key="n"
-                >
-                  <v-list-item-avatar color="grey darken-1">
-                  </v-list-item-avatar>
-
-                  <v-list-item-content>
-                    <v-list-item-title>Message {{ n }}</v-list-item-title>
-
-                    <v-list-item-subtitle>
-                      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nihil repellendus distinctio similique
-                    </v-list-item-subtitle>
-                    <div class="d-flex flex-row justify-end">
-                      <template v-for="m in 3">
-                        <v-chip
-                          x-small
-                          class="ma-2"
-                          color="green"
-                          text-color="white"
-                          :key="m"
-                          >
-                          タグ
-                        </v-chip>
-                      </template>
-                      <v-icon x-small>mdi-message</v-icon><span class="ma-2" style="font-size : x-small">コメント数</span>
-                      <v-icon x-small>mdi-thumb-up-outline</v-icon><span class="ma-2" style="font-size : x-small">いいね数</span>
-                    </div>
-                  </v-list-item-content>
-                </v-list-item>
-
-                <v-divider
-                  v-if="n !== 6"
-                  :key="`divider-${n}`"
-                  inset
-                ></v-divider>
-              </template>
-            </v-list>
-          </v-card>
-          <div class="d-flex flex-row justify-end mt-2">
-            <v-btn to="/">こちら</v-btn>
-          </div>
-        </v-col>
+        <announcementsCard :announcements="announcements"/>
+        <RecentReportsCard :recentReports="recentReports"/>
+        <ReportsOfFollowingUserCard :reportsOfFollowingUser="reportsOfFollowingUser"/>
       </v-row>
     </v-container>
 </template>
 
 <script>
+import announcementsCard from '../components/announcementsCard.vue';
+import RecentReportsCard from '../components/recentReportsCard.vue';
+import ReportsOfFollowingUserCard from '../components/reportsOfFollowingUserCard.vue';
   export default {
+  components: { announcementsCard, RecentReportsCard, ReportsOfFollowingUserCard },
     data: () => ({
-      // 将来的に、cardの中身はオブジェクト化し、3コンテンツそれぞれでtitle, 取得データ, リンクなどを設定する
-      cards: ['お知らせ一覧', '最近投稿された月報','フォローしているユーザーの月報'],
+      announcements: {
+        contentTitle: 'お知らせ',
+        data: [],
+      },
+      recentReports: {
+        contentTitle: '最近投稿された月報',
+        data: [],
+      },
+      reportsOfFollowingUser: {
+        contentTitle: 'フォローしているユーザーの月報',
+        data: [],
+      },
     }),
+    created(){
+      this.fetchTopInfo();
+    },
+    methods: {
+      async fetchTopInfo(){
+        const res = await this.$axios.get('/api/top');
+        // console.log(res.data);
+        this.announcements.data = res.data[0];
+        this.recentReports.data = res.data[1];
+        this.reportsOfFollowingUser.data = res.data[2];
+      },
+    },
     name: 'indexページ',
   }
 </script>


### PR DESCRIPTION
## 対応チケット
[DASH_31 管理者トップ画面にバックエンドから情報を受け渡す](https://gonzuiswimmer.atlassian.net/browse/DASH-31)

## やったこと
* APIで取得したデータをトップ画面に表示
* 3つのコンテンツ欄をコンポーネントで切り出し、データを受け渡し
* created時に非同期でAPIから情報を取得

## 動作確認
- 画面キャプチャなど
<img width="734" alt="image" src="https://github.com/gonzuiswimmer/dash_replace2_front/assets/115978255/6414bf1c-39d0-43a3-bef1-b56085b85a29">


## その他
- お知らせ情報にユーザー情報が不足しているため、別チケットにてAPIの修正を予定
[DASH_35 トップ画面のお知らせ一覧レスポンスにデータを追加する](https://gonzuiswimmer.atlassian.net/browse/DASH-35)
