### PR TITLE
Dash32_管理者ユーザーと一般ユーザーで表示するページを制限

### DIFF
--- a/components/NavigationDrawer.vue
+++ b/components/NavigationDrawer.vue
@@ -135,11 +135,15 @@ export default {
     async logout() {
       try{
         const response = await this.$auth.logout();
+        await this.resetUserRole();
         console.log(response);
       }catch(error){
         console.log(error);
       }
-    }
+    },
+    resetUserRole(){
+      this.$store.commit('role/resetUserRole')
+    },
   }
 }
 </script>

--- a/middleware/judgeAdmin.js
+++ b/middleware/judgeAdmin.js
@@ -1,0 +1,9 @@
+export default function ({ store, redirect, route }) {
+
+  // role.jsのroleステートがadminかつ、ルーティングにadminが含まれていればログイン画面にリダイレクト
+  if (store.state.role.role != 'admin' && route.path.indexOf('admin') > -1 ){
+    console.log(route.path.indexOf('admin'));
+    alert('アクセスする権限がありません');
+    redirect('/login');
+  }
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -24,7 +24,9 @@ export default {
   css: [],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
-  plugins: [],
+  plugins: [
+    {src: '~/plugins/persistedState.js', ssr: false}
+  ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,
@@ -47,7 +49,7 @@ export default {
   auth: {
     redirect: {
       login: '/login',
-      logout: '/',
+      logout: '/login',
       callback: false,
       home: '/'
     },
@@ -68,7 +70,7 @@ export default {
   },
 
   router: {
-    middleware: ['auth']
+    middleware: ['auth', 'judgeAdmin']
   },
 
   // Axios module configuration: https://go.nuxtjs.dev/config-axios

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "vue": "^2.7.10",
         "vue-server-renderer": "^2.7.10",
         "vue-template-compiler": "^2.7.10",
-        "vuetify": "^2.6.10"
+        "vuetify": "^2.6.10",
+        "vuex-persistedstate": "^3.2.1"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.19.1",
@@ -19575,6 +19576,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shvl": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/shvl/-/shvl-2.0.3.tgz",
+      "integrity": "sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==",
+      "deprecated": "older versions vulnerable to prototype pollution"
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -21690,6 +21697,20 @@
       "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
       "peerDependencies": {
         "vue": "^2.0.0"
+      }
+    },
+    "node_modules/vuex-persistedstate": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-3.2.1.tgz",
+      "integrity": "sha512-0OnHKGsCHJcvbEraaGZvuvX4aybM2oQWYRuZmIQB7zUjVM6tP+Hg+oXLrq9r6elT4she9SGtEbGE1L2+XdFgUw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "shvl": "^2.0.3"
+      },
+      "peerDependencies": {
+        "vue": "^2.0.0",
+        "vuex": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "vue": "^2.7.10",
     "vue-server-renderer": "^2.7.10",
     "vue-template-compiler": "^2.7.10",
-    "vuetify": "^2.6.10"
+    "vuetify": "^2.6.10",
+    "vuex-persistedstate": "^3.2.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.19.1",

--- a/pages/admin/users/create.vue
+++ b/pages/admin/users/create.vue
@@ -1,0 +1,15 @@
+<template>
+    <div>
+    <h1>admin.users.createページ</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/pages/admin/users/edit/_id.vue
+++ b/pages/admin/users/edit/_id.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>admin.users.edit.{{ $route.params.id }}ページ</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/pages/admin/users/index.vue
+++ b/pages/admin/users/index.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>admin.users.indexページ</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/pages/admin/users/show/_id.vue
+++ b/pages/admin/users/show/_id.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>admin.users.show_{{ $route.params.id }}ページ</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/pages/admin/users/store.vue
+++ b/pages/admin/users/store.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>admin.users.storeページ</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -37,12 +37,14 @@
       async login() {
         try {
           const response = await this.$auth.loginWith('laravelSanctum', { data: this.form });
-          this.$auth.setUser(response.data[0]);
-          await this.$auth.fetchUser();
+          await this.setUserRole(response.data['role']);
           console.log(response);
         } catch(error) {
           console.log(error);
         }
+      },
+      setUserRole(role){
+        this.$store.commit('role/setUserRole',role)
       },
     },
   };

--- a/plugins/persistedState.js
+++ b/plugins/persistedState.js
@@ -1,0 +1,8 @@
+import createPersistedState from 'vuex-persistedstate'
+
+export default ({ store }) => {
+  createPersistedState({
+    key: 'userRole',
+    paths: ['role']
+  })(store)
+}

--- a/store/role.js
+++ b/store/role.js
@@ -1,0 +1,27 @@
+export const state = () => ({
+  role: ''
+})
+
+export const getters = {
+  // getCounter(state) {
+  //   return state.counter
+  // }
+}
+
+export const mutations = {
+  setUserRole(state, role){
+    state.role = role;
+  },
+  resetUserRole(state){
+    state.role = ''
+  }
+}
+
+export const actions = {
+  // async fetchCounter({ state }) {
+  //   // make request
+  //   const res = { data: 10 };
+  //   state.counter = res.data;
+  //   return res.data;
+  // }
+}


### PR DESCRIPTION
## 対応チケット
[Dash32_管理者ユーザーと一般ユーザーで表示するページを制限](https://gonzuiswimmer.atlassian.net/browse/DASH-32)

## やったこと
- vuex-persistedstateの導入
- カスタムストアの作成、ストアに情報を保持する処理を実装
- 閲覧制限のミドルウェアを作成
- 上記それぞれの環境を設定
- 管理者関連ページを作成

## 動作確認
- 管理者でログイン
  * store.state.roleがadminになる
  * admin/* にアクセスできる
- 一般ユーザーでログイン
  * store.state.roleがotherになる
  * admin/*にアクセスするとアラートが表示され、ログイン画面にリダイレクトする

## その他

