### PR TITLE
DASH_35 トップ画面のお知らせ一覧レスポンスにデータを追加する

### DIFF
--- a/components/NavigationDrawer.vue
+++ b/components/NavigationDrawer.vue
@@ -132,6 +132,11 @@ export default {
           to: '/',
         },
         {
+          icon: 'mdi-account',
+          title: this.$auth.user.name,
+          to: '/',
+        },
+        {
           icon: 'mdi-chart-bubble',
           title: 'プロフィール',
           to: '/inspire',
@@ -206,6 +211,11 @@ export default {
         {
           icon: 'mdi-magnify',
           title: 'ユーザー検索',
+          to: '/',
+        },
+        {
+          icon: 'mdi-account',
+          title: this.$auth.user.name,
           to: '/',
         },
         {

--- a/components/announcementsCard.vue
+++ b/components/announcementsCard.vue
@@ -7,30 +7,13 @@
           <v-list-item
             :key="index"
           >
-            <v-list-item-avatar color="grey darken-1">
-            </v-list-item-avatar>
 
             <v-list-item-content>
-              <v-list-item-title>名前 <span>【所属:yyy年mm月入社】</span> </v-list-item-title>
-
               <v-list-item-subtitle>
-                {{ content.title }}
+                {{ content.published_date }}
               </v-list-item-subtitle>
-              <div class="d-flex flex-row justify-end">
-                <template v-for="m in 3">
-                  <v-chip
-                    x-small
-                    class="ma-2"
-                    color="green"
-                    text-color="white"
-                    :key="m"
-                    >
-                    タグ
-                  </v-chip>
-                </template>
-                <v-icon x-small>mdi-message</v-icon><span class="ma-2" style="font-size : x-small">コメント数</span>
-                <v-icon x-small>mdi-thumb-up-outline</v-icon><span class="ma-2" style="font-size : x-small">いいね数</span>
-              </div>
+              <v-list-item-title>{{ content.title }}</v-list-item-title>
+
             </v-list-item-content>
           </v-list-item>
 
@@ -43,7 +26,7 @@
       </v-list>
     </v-card>
     <div class="d-flex flex-row justify-end mt-2">
-      <v-btn to="/">{{ announcements.contentTitle }}一覧はこちら</v-btn>
+      <v-btn text color="primary" to="index">{{ announcements.contentTitle }}一覧はこちら</v-btn>
     </div>
   </v-col>
 </template>

--- a/components/recentReportsCard.vue
+++ b/components/recentReportsCard.vue
@@ -11,7 +11,7 @@
             </v-list-item-avatar>
 
             <v-list-item-content>
-              <v-list-item-title>{{ content.user.name }}<span>【所属:{{content.user.department_id}}/{{content.user.entry_date}}入社】</span> </v-list-item-title>
+              <v-list-item-title>{{ content.user.name }}<span>【所属:{{getDepartmentName(content.user.department_id)}}/{{content.user.entry_date}}入社】</span> </v-list-item-title>
 
               <v-list-item-subtitle>
                 {{ content.business_content }}
@@ -43,7 +43,7 @@
       </v-list>
     </v-card>
     <div class="d-flex flex-row justify-end mt-2">
-      <v-btn to="/">{{ recentReports.contentTitle }}一覧はこちら</v-btn>
+      <v-btn to="index" text color="primary">{{ recentReports.contentTitle }}一覧はこちら</v-btn>
     </div>
   </v-col>
 </template>
@@ -54,6 +54,27 @@ export default {
     recentReports: {
       type: Object,
       default: {},
+    }
+  },
+  methods: {
+    getDepartmentName(id) {
+      if (id === 1) {
+        return 'WEB'
+      } else if (id === 2) {
+        return 'CL'
+      } else if (id === 3) {
+        return 'ML'
+      } else if (id === 4) {
+        return '内勤'
+      } else if (id === 5) {
+        return '未設定'
+      } else if (id === 6) {
+        return 'FR'
+      } else if (id === 7) {
+        return 'QA'
+      } else if (id === 8) {
+        return 'PHP'
+      }
     }
   }
 }

--- a/components/reportsOfFollowingUserCard.vue
+++ b/components/reportsOfFollowingUserCard.vue
@@ -11,7 +11,7 @@
             </v-list-item-avatar>
 
             <v-list-item-content>
-              <v-list-item-title>{{ content.user.name }}<span>【所属:{{content.user.department_id}}/{{content.user.entry_date}}入社】</span> </v-list-item-title>
+              <v-list-item-title>{{ content.user.name }}<span>【所属:{{getDepartmentName(content.user.department_id)}}/{{content.user.entry_date}}入社】</span> </v-list-item-title>
 
               <v-list-item-subtitle>
                 {{ content.business_content }}
@@ -43,7 +43,7 @@
       </v-list>
     </v-card>
     <div class="d-flex flex-row justify-end mt-2">
-      <v-btn to="/">{{ reportsOfFollowingUser.contentTitle }}一覧はこちら</v-btn>
+      <v-btn text color="primary" to="index" >{{ reportsOfFollowingUser.contentTitle }}一覧はこちら</v-btn>
     </div>
   </v-col>
 </template>
@@ -54,6 +54,27 @@ export default {
     reportsOfFollowingUser: {
       type: Object,
       default: {},
+    }
+  },
+  methods: {
+    getDepartmentName(id) {
+      if (id === 1) {
+        return 'WEB'
+      } else if (id === 2) {
+        return 'CL'
+      } else if (id === 3) {
+        return 'ML'
+      } else if (id === 4) {
+        return '内勤'
+      } else if (id === 5) {
+        return '未設定'
+      } else if (id === 6) {
+        return 'FR'
+      } else if (id === 7) {
+        return 'QA'
+      } else if (id === 8) {
+        return 'PHP'
+      }
     }
   }
 }


### PR DESCRIPTION
## 対応チケット
[DASH_35 トップ画面のお知らせ一覧レスポンスにデータを追加する](https://gonzuiswimmer.atlassian.net/browse/DASH-35)

## やったこと
- お知らせ欄の不要項目を削除し、必要な情報が表示されるようにレイアウトを修正
- 他コンテンツ欄の部署情報の部署名が表示されるように修正
- ナビゲーションメニューバーにログインユーザー名を追加

## 動作確認
- 必要な情報が表示されている

## その他
- レスポンスにデータを追加する必要がなかったため、バックエンドの変更はなし
