### PR TITLE
Dash_43 管理者一覧画面

### DIFF
--- a/components/NavigationDrawer.vue
+++ b/components/NavigationDrawer.vue
@@ -133,7 +133,7 @@ export default {
         },
         {
           icon: 'mdi-account',
-          title: this.$auth.user.name,
+          title: this.$auth.user ? this.$auth.user.name : '',
           to: '/',
         },
         {
@@ -215,7 +215,7 @@ export default {
         },
         {
           icon: 'mdi-account',
-          title: this.$auth.user.name,
+          title: this.$auth.user ? this.$auth.user.name : '',
           to: '/',
         },
         {

--- a/pages/admin/users/edit/_id.vue
+++ b/pages/admin/users/edit/_id.vue
@@ -247,7 +247,6 @@
       },
       async destroyUser(){
         try {
-          console.log('動作確認');
           await this.$axios.patch(`/api/admin/users/destroy/${this.$route.params['id']}`)
           .then((response) => {
             if(response.data.DestroyUserResult){

--- a/pages/admin/users/showRoles.vue
+++ b/pages/admin/users/showRoles.vue
@@ -1,0 +1,72 @@
+<template>
+  <div>
+    <v-card width="800px" class="mx-auto mt-5">
+      <v-card-title>
+        <h2 class="display-8">管理者一覧</h2>
+      </v-card-title>
+      <v-card-text v-if="users !== null">
+        <v-list-item v-for="user in users" :key="user.id">
+          <v-list-item-content>
+            <v-list-item-title>{{ user.name }}</v-list-item-title>
+            <v-list-item-subtitle>{{ user.entry_date }} <span>【{{ user.department.name }}】</span> </v-list-item-subtitle>
+          </v-list-item-content>
+
+          <v-list-item-action>
+            <v-btn icon>
+            <v-icon color="red lighten-1" @click="deleteAdminUsersRole(user.id)">mdi-close-circle</v-icon>
+            </v-btn>
+          </v-list-item-action>
+        </v-list-item>
+      </v-card-text>
+
+      <v-card-text v-else>
+        該当のユーザーは存在しません
+      </v-card-text>
+    </v-card>
+  </div>
+</template>
+
+<script>
+export default {
+  data(){
+    return {
+      users: [],
+    }
+  },
+  mounted(){
+    this.fetchAdminUsers();
+  },
+  methods: {
+    async deleteAdminUsersRole(id){
+      try {
+        const response = await this.$axios.delete(`/api/admin/users/roles/delete/${id}`)
+        .then((response) => {
+          if(response.data.destroyAdminUserRoleResult) {
+            this.fetchAdminUsers();
+            alert('管理者からユーザーを削除しました');
+          } else {
+            alert('処理に失敗しました');
+          }
+        })
+      } catch (error) {
+        console.log(error);
+        alert(error.response.data.message);
+      }
+    },
+    async fetchAdminUsers(){
+      try {
+        const response = await this.$axios.get('/api/admin/users/roles')
+        .then((response) => {
+          this.users = response.data.users
+        });
+      } catch (error) {
+        console.log(error);
+      }
+    },
+  },
+}
+</script>
+
+<style>
+
+</style>


### PR DESCRIPTION
## 対応チケット

[DASH_43 管理者一覧画面](https://gonzuiswimmer.atlassian.net/browse/DASH-43)

## やったこと
- 管理者一覧画面の実装
- 管理者削除機能の実装

## 動作確認
### 画面
<img width="549" alt="image" src="https://github.com/gonzuiswimmer/dash_replace2_front/assets/115978255/78668bc0-ca7a-464f-b14a-f4130c6abb38">


## その他
- なし
