### PR TITLE
DASH_34 パスワードリセット機能の実装および動作確認_front

### DIFF
--- a/middleware/getDepartments.js
+++ b/middleware/getDepartments.js
@@ -1,7 +1,10 @@
 export default async function ({ store, route }) {
   const currentPath =  route.path
+  const excludePath = ['/login','/resetPassword','/forgotPassword'];
 
-  if ( !store.state.department.departments.length && currentPath !== '/login'  ){
-    await store.dispatch('department/fetchDepartments')
-  }
+  if ( !store.state.department.departments.length ){
+    if( !excludePath.includes(currentPath) ){
+      await store.dispatch('department/fetchDepartments');
+    };
+  };
 }

--- a/middleware/judgeAdmin.js
+++ b/middleware/judgeAdmin.js
@@ -4,6 +4,6 @@ export default function ({ store, redirect, route }) {
   if (store.state.role.role != 'admin' && route.path.indexOf('admin') > -1 ){
     console.log(route.path.indexOf('admin'));
     alert('アクセスする権限がありません');
-    redirect('/login');
+    redirect('/');
   }
 }

--- a/pages/forgotPassword.vue
+++ b/pages/forgotPassword.vue
@@ -37,11 +37,13 @@
         try {
           const response = await this.$axios.post('/forgot-password', this.form)
           .then((response) => {
-            alert('パスワードリセットメールを送信しました。');
-            this.$router.push('/passwordReset');
+            if(response.data[0] == 'passwords.sent'){
+              alert('パスワードリセットメールを送信しました。メールを確認してパスワードリセットリンクをクリックしてください');
+            }else{
+              alert(response.data.email);
+            }
           });
         } catch(error) {
-          console.log(error);
           alert(error.response.data.message);
         }
       },

--- a/pages/forgotPassword.vue
+++ b/pages/forgotPassword.vue
@@ -1,0 +1,53 @@
+<template>
+  <div>
+    <v-card width="400px" class="mx-auto mt-5">
+      <v-card-title>
+        <h1 class="display-1">パスワードをお忘れですか？</h1>
+        <h2>メールアドレスを入力してください。新しいパスワードを選択できるパスワードリセットリンクをメールアドレスでお送りします。</h2>
+      </v-card-title>
+      <v-card-text>
+        <v-form @submit.prevent="resendVerifyEmail()">
+          <v-text-field prepend-icon="mdi-email-outline" type="email" label="メールアドレス" v-model="form.email"  />
+          <v-card-actions>
+            <v-btn type="submit" class="info">パスワードリセットリンクをメールで送信</v-btn>
+          </v-card-actions>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </div>
+</template>
+
+<script>
+  export default {
+    auth: false,
+    data() {
+      return {
+        form: {
+          email: '',
+        },
+      };
+    },
+    mounted() {
+      // csrf対策
+      // nginxでRPする場合は/sanctumがapi側を見に行くようにしてください
+      this.$axios.get('/sanctum/csrf-cookie');
+    },
+    methods: {
+      async resendVerifyEmail() {
+        try {
+          const response = await this.$axios.post('/forgot-password', this.form)
+          .then((response) => {
+            alert('パスワードリセットメールを送信しました。');
+            this.$router.push('/passwordReset');
+          });
+        } catch(error) {
+          console.log(error);
+          alert(error.response.data.message);
+        }
+      },
+      showMessage(message){
+        alert(message);
+      }
+    },
+  };
+</script>

--- a/pages/forgotPassword.vue
+++ b/pages/forgotPassword.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <v-card width="400px" class="mx-auto mt-5">
+    <v-card width="700px" class="mx-auto mt-5">
       <v-card-title>
         <h1 class="display-1">パスワードをお忘れですか？</h1>
-        <h2>メールアドレスを入力してください。新しいパスワードを選択できるパスワードリセットリンクをメールアドレスでお送りします。</h2>
+        <p>メールアドレスを入力してください。新しいパスワードを選択できるパスワードリセットリンクをメールアドレスでお送りします。</p>
       </v-card-title>
       <v-card-text>
         <v-form @submit.prevent="resendVerifyEmail()">

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -10,6 +10,7 @@
           <v-text-field prepend-icon="mdi-lock" v-bind:append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'" label="パスワード" v-bind:type="showPassword ? 'text' : 'password'" @click:append="showPassword = !showPassword" v-model="form.password" />
           <v-card-actions>
             <v-btn type="submit" class="info">ログイン</v-btn>
+            <v-btn class="ml-auto" text color="primary" to="forgotPassword">パスワードをお忘れの方はこちら</v-btn>
           </v-card-actions>
         </v-form>
       </v-card-text>

--- a/pages/resetPassword.vue
+++ b/pages/resetPassword.vue
@@ -43,12 +43,14 @@
         try {
           const response = await this.$axios.post('/reset-password', this.form)
           .then((response) => {
-            alert('パスワードを再設定しました');
-            console.log(response);
-            this.$router.push('/login');
+            if(response.data[0] == 'passwords.reset'){
+              alert('パスワードを再設定しました。');
+              this.$router.push('/login');
+            }else{
+              alert(response.data.email);
+            }
           });
         } catch(error) {
-          console.log(error);
           alert(error.response.data.message);
         }
       },

--- a/pages/resetPassword.vue
+++ b/pages/resetPassword.vue
@@ -1,0 +1,60 @@
+<template>
+  <div>
+    <v-card width="400px" class="mx-auto mt-5">
+      <v-card-title>
+        <h1 class="display-1">パスワードをお忘れですか？</h1>
+      </v-card-title>
+      <v-card-text>
+        <v-form @submit.prevent="passwordReset()">
+          <v-text-field prepend-icon="mdi-email-outline" type="email" label="メールアドレス" v-model="form.email"  />
+          <v-text-field prepend-icon="mdi-lock" v-bind:append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'" label="パスワード" v-bind:type="showPassword ? 'text' : 'password'" @click:append="showPassword = !showPassword" v-model="form.password" />
+          <v-text-field prepend-icon="mdi-lock" v-bind:append-icon="showConfirmPassword ? 'mdi-eye' : 'mdi-eye-off'" label="パスワード" v-bind:type="showConfirmPassword ? 'text' : 'password'" @click:append="showConfirmPassword = !showConfirmPassword" v-model="form.password_confirmation" />
+          <v-card-actions>
+            <v-btn type="submit" class="info">パスワードを再設定する</v-btn>
+          </v-card-actions>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </div>
+</template>
+
+<script>
+  export default {
+    auth: false,
+    data() {
+      return {
+        showPassword: false,
+        showConfirmPassword: false,
+        form: {
+          email: this.$route.query.email || '',
+          password: '',
+          password_confirmation: '',
+          token: this.$route.query.token || '',
+        },
+      };
+    },
+    mounted() {
+      // csrf対策
+      // nginxでRPする場合は/sanctumがapi側を見に行くようにしてください
+      this.$axios.get('/sanctum/csrf-cookie');
+    },
+    methods: {
+      async passwordReset() {
+        try {
+          const response = await this.$axios.post('/reset-password', this.form)
+          .then((response) => {
+            alert('パスワードを再設定しました');
+            console.log(response);
+            this.$router.push('/login');
+          });
+        } catch(error) {
+          console.log(error);
+          alert(error.response.data.message);
+        }
+      },
+      showMessage(message){
+        alert(message);
+      }
+    },
+  };
+</script>

--- a/store/department.js
+++ b/store/department.js
@@ -23,7 +23,7 @@ export const mutations = {
 
 export const actions = {
   async fetchDepartments({ commit }) {
-    await this.$axios.get('/api/admin/users/getDepartments')
+    await this.$axios.get('/api/getDepartments')
     .then((res) => {
       commit('setDepartments',res.data[0])
     })

--- a/store/department.js
+++ b/store/department.js
@@ -23,7 +23,7 @@ export const mutations = {
 
 export const actions = {
   async fetchDepartments({ commit }) {
-    await this.$axios.get('/api/getDepartments')
+    await this.$axios.get('/api/admin/users/getDepartments')
     .then((res) => {
       commit('setDepartments',res.data[0])
     })


### PR DESCRIPTION
## 対応チケット
[DASH_34 パスワードリセット機能の実装および動作確認_front](https://gonzuiswimmer.atlassian.net/browse/DASH-34)

## やったこと
- パスワードリセット機能の実装（メール再送信画面、パスワードリセット画面の実装）
- バックエンドの修正

## 動作確認

![パスワードリセット機能_フロント](https://github.com/gonzuiswimmer/dash_replace2_front/assets/115978255/5f3737c1-bb21-45c1-b952-b53c119ba5ac)

## その他

